### PR TITLE
Upgraded all dependencies to latest.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ scalacOptions ++= Seq("-deprecation", "-feature")
 
 libraryDependencies ++= Seq(
   "org.sangria-graphql" %% "sangria-streaming-api" % "1.0.0",
-  "com.typesafe.akka" %% "akka-stream" % "2.4.16",
+  "com.typesafe.akka" %% "akka-stream" % "2.5.12",
   "org.scalatest" %% "scalatest" % "3.0.1" % "test"
 )
 

--- a/project/sbt-updates.sbt
+++ b/project/sbt-updates.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.3.4")

--- a/src/main/scala/sangria/streaming/akkaStreams.scala
+++ b/src/main/scala/sangria/streaming/akkaStreams.scala
@@ -2,16 +2,22 @@ package sangria.streaming
 
 import scala.language.higherKinds
 import akka.NotUsed
+import akka.event.Logging
 import akka.stream.ActorAttributes.SupervisionStrategy
-import akka.stream.{Attributes, Materializer, Supervision}
-import akka.stream.impl.fusing.GraphStages.SimpleLinearGraphStage
+import akka.stream._
 import akka.stream.scaladsl.{Merge, Sink, Source}
-import akka.stream.stage.{GraphStageLogic, InHandler, OutHandler}
+import akka.stream.stage.{GraphStage, GraphStageLogic, InHandler, OutHandler}
 
 import scala.concurrent.Future
 
 object akkaStreams {
   type AkkaSource[+T] = Source[T, NotUsed]
+
+  abstract class SimpleLinearGraphStage[T] extends GraphStage[FlowShape[T, T]] {
+    val in = Inlet[T](Logging.simpleName(this) + ".in")
+    val out = Outlet[T](Logging.simpleName(this) + ".out")
+    override val shape = FlowShape(in, out)
+  }
 
   class AkkaStreamsSubscriptionStream(implicit materializer: Materializer) extends SubscriptionStream[AkkaSource] {
     def supported[T[_]](other: SubscriptionStream[T]) = other.isInstanceOf[AkkaStreamsSubscriptionStream]

--- a/src/test/scala/sangria/streaming/AkkStreamsIntegrationSpec.scala
+++ b/src/test/scala/sangria/streaming/AkkStreamsIntegrationSpec.scala
@@ -1,4 +1,4 @@
-package sangria.streaming
+ package sangria.streaming
 
 import java.util.concurrent.atomic.AtomicInteger
 


### PR DESCRIPTION
Hi, I'm trying to use https://github.com/reta/sangria-akka-http-graphql using the latest versions of all libs and am failing to compile because of changes to akka.
In this pull-request, I've upgraded all the libs and worked around SimpleLinearGraphStage becoming private.
Thanks,
M.